### PR TITLE
Solve error when using flysystem-cached-adapter

### DIFF
--- a/src/Support/UrlGenerator/DefaultUrlGenerator.php
+++ b/src/Support/UrlGenerator/DefaultUrlGenerator.php
@@ -28,7 +28,13 @@ class DefaultUrlGenerator extends BaseUrlGenerator
 
     public function getPath(): string
     {
-        $pathPrefix = $this->getDisk()->getAdapter()->getPathPrefix();
+        $pathPrefix = '';
+        
+        $adapter = $this->getDisk()->getAdapter();
+        
+        if (method_exists($adapter, 'getPathPrefix')) {
+            $pathPrefix = $adapter->getPathPrefix();
+        }
 
         return $pathPrefix.$this->getPathRelativeToRoot();
     }


### PR DESCRIPTION
Hi,

This change solves the error triggered on conversions when using an s3 driver disk:

`Call to undefined method League\Flysystem\Cached\CachedAdapter::getPathPrefix() in /home/vagrant/laravel-app/vendor/spatie/laravel-medialibrary/src/Support/UrlGenerator/DefaultUrlGenerator.php:31`

Fixes #1800